### PR TITLE
VPIMEXT-239: added logic to recover from panic error

### DIFF
--- a/ndt7/download/wait_for_message.go
+++ b/ndt7/download/wait_for_message.go
@@ -23,6 +23,13 @@ func WaitForMessage(ctx context.Context, conn *websocket.Conn, MaxMsgSize int64)
 	currentChannel := make(chan string, 1)
 
 	go func() {
+
+		defer func() {
+			if err := recover(); err != nil {
+				logging.Logger.Warn("wait_for_message: panic occurred")
+			}
+		}()
+
 		for receiverctx.Err() == nil { // Liveness!
 			mtype, r, err := conn.NextReader()
 			if err != nil {

--- a/ndt7/download/wait_for_message.go
+++ b/ndt7/download/wait_for_message.go
@@ -17,7 +17,7 @@ func WaitForMessage(ctx context.Context, conn *websocket.Conn, MaxMsgSize int64)
 	defer logging.Logger.Debug("wait_for_message: stop")
 	conn.SetReadLimit(MaxMsgSize)
 
-	receiverctx, cancel := context.WithTimeout(ctx, spec.MaxRuntime)
+	receiverctx, cancel := context.WithTimeout(ctx, spec.WaitForMessageTimeout)
 	defer cancel()
 
 	currentChannel := make(chan string, 1)


### PR DESCRIPTION
What Mikolaj found out is that the resource unavailable error is happening because the NDT server is throwing a panic error after 2 threads are trying to write to the same WebSocket. Most likely waiting for the message thread is theoretically timing out and the download test is starting, but the logic from the goroutine is still working and is trying to write to the WebSocket at the same time as the download logic. It is reproducible easily by downgrading your local network to 1Mbps and 100ms latency for example.

For now, those changes are handling the panic error through the recover() function so the test won't fail in this case. The best solution would be to better handle the concurrency here and properly shut down the wait for message logic, but as of right now, we didn't know how to do that properly in Go. @skostuch do you think that this solution is fine for now and we should tackle this issue in another ticket?